### PR TITLE
Modified FragmentAdapter.java and MainActivity.java

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+ViewPager2Tabs

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,7 +4,7 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="PLATFORM" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="1.8" />
@@ -15,7 +15,6 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/com/example/viewpager2tabs/FragmentAdapter.java
+++ b/app/src/main/java/com/example/viewpager2tabs/FragmentAdapter.java
@@ -1,5 +1,7 @@
 package com.example.viewpager2tabs;
 
+import android.content.Context;
+
 import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -7,8 +9,14 @@ import androidx.lifecycle.Lifecycle;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
 public class FragmentAdapter extends FragmentStateAdapter {
-    public FragmentAdapter(@NonNull FragmentManager fragmentManager, @NonNull Lifecycle lifecycle) {
+
+    Context context;
+    int totalTabCount;
+
+    public FragmentAdapter(Context context, @NonNull FragmentManager fragmentManager, @NonNull Lifecycle lifecycle, int totalTabCount) {
         super(fragmentManager, lifecycle);
+        this.context = context;
+        this.totalTabCount = totalTabCount;
     }
 
     @NonNull
@@ -28,6 +36,6 @@ public class FragmentAdapter extends FragmentStateAdapter {
 
     @Override
     public int getItemCount() {
-        return 3;
+        return totalTabCount;
     }
 }

--- a/app/src/main/java/com/example/viewpager2tabs/MainActivity.java
+++ b/app/src/main/java/com/example/viewpager2tabs/MainActivity.java
@@ -23,7 +23,7 @@ public class MainActivity extends AppCompatActivity {
         pager2 = findViewById(R.id.view_pager2);
 
         FragmentManager fm = getSupportFragmentManager();
-        adapter = new FragmentAdapter(fm, getLifecycle());
+        adapter = new FragmentAdapter(this, fm, getLifecycle(), tabLayout.getTabCount());
         pager2.setAdapter(adapter);
 
         tabLayout.addTab(tabLayout.newTab().setText("First"));


### PR DESCRIPTION
Added int totalTabCount to fetch the number of tabs and Context

`Context context;
    int totalTabCount;

    public FragmentAdapter(Context context, @NonNull FragmentManager fragmentManager, @NonNull Lifecycle lifecycle, int totalTabCount) {
        super(fragmentManager, lifecycle);
        this.context = context;
        this.totalTabCount = totalTabCount;
    }`

`getItemCount()` will now return totalTabCount instead of a static number 3

```
@Override
    public int getItemCount() {
        return totalTabCount;
    }
```

The method will no longer have to be modified when another fragment is added
Updated MainActivity with the new changes
```
FragmentManager fm = getSupportFragmentManager();
 adapter = new FragmentAdapter(this, fm, getLifecycle(), tabLayout.getTabCount());
 pager2.setAdapter(adapter);
```